### PR TITLE
Explicitly close dup'ed file descriptor when we dont need it anymore

### DIFF
--- a/failfast_darwin.go
+++ b/failfast_darwin.go
@@ -14,5 +14,7 @@ func ff(tcp *net.TCPConn, timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
-	return unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, unix.TCP_RXT_CONNDROPTIME, int(timeout/time.Second))
+	err = unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, unix.TCP_RXT_CONNDROPTIME, int(timeout/time.Second))
+	fd.Close()
+	return err
 }

--- a/failfast_linux.go
+++ b/failfast_linux.go
@@ -15,5 +15,7 @@ func ff(tcp *net.TCPConn, timeout time.Duration) error {
 		return err
 	}
 	const tcpUserTimeout = 0x12
-	return unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, tcpUserTimeout, int(timeout/time.Millisecond))
+	err = unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, tcpUserTimeout, int(timeout/time.Millisecond))
+	fd.Close()
+	return err
 }


### PR DESCRIPTION
Leaving  FD cleanup up to GC is a bit untidy.